### PR TITLE
Organize package properties

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,4 @@
-﻿param([switch]$pack)
+param([switch]$pack)
 
 $ErrorActionPreference = "Stop"
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Packaging -->
+    <!-- Package Metadata -->
     <Authors>Fixie, Patrick Lioi</Authors>
     <Copyright>Copyright (c) 2024 Patrick Lioi</Copyright>
     <Description>Ergonomic Assertions for .NET</Description>
@@ -15,6 +15,10 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <!-- Packaging -->
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,19 +6,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Package Metadata -->
-    <Authors>Fixie, Patrick Lioi</Authors>
-    <Copyright>Copyright (c) 2024 Patrick Lioi</Copyright>
-    <Description>Ergonomic Assertions for .NET</Description>
-    <PackageProjectUrl>https://fixie.github.io</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/fixie/fixie.assertions</RepositoryUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageIcon>icon.png</PackageIcon>
-  </PropertyGroup>
-  
-  <PropertyGroup>
-    <!-- Packaging -->
     <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/Fixie.Assertions/Fixie.Assertions.csproj
+++ b/src/Fixie.Assertions/Fixie.Assertions.csproj
@@ -3,6 +3,14 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Authors>Fixie, Patrick Lioi</Authors>
+    <Copyright>Copyright (c) 2024 Patrick Lioi</Copyright>
+    <Description>Ergonomic Assertions for .NET</Description>
+    <PackageProjectUrl>https://fixie.github.io</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/fixie/fixie.assertions</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There are two categories of MSBuild properties related to `dotnet pack`:

1. Properties that govern how to go about creating packages in general: deterministic builds, package file format. You want these always set solution wide so they are never forgotten by accident as the project composition of a solution changes over time.
2. Properties that provide metadata content within packages. These appear inside the package in the generated nuspec file, and legacy packaging would involve manually writing them into a nuspec file used at packaging time. Now that modern csproj essentially plays the role of the legacy nuspec file, these properties generally belong at the project level. In a solution that gains multiple packable projects over time, some of these could be promoted to the solution level to reduce duplication on a case by case basis.

By placing these properties in their ideal locations, you reduce the risks of unintended omission for solution level concerns and reduce the risk of unintended duplication for package level concerns.