### PR TITLE
Failure messaging

### DIFF
--- a/src/Fixie.Assertions.Tests/BoolTests.cs
+++ b/src/Fixie.Assertions.Tests/BoolTests.cs
@@ -17,8 +17,8 @@ class BoolTests
         true.ShouldBe(true);
         false.ShouldBe(false);
 
-        Contradiction(true, x => x.ShouldBe(false), "x should be false but was true");
-        Contradiction(false, x => x.ShouldBe(true), "x should be true but was false");
+        Contradiction(true, x => x.ShouldBe(false), Inequality("false", "true"));
+        Contradiction(false, x => x.ShouldBe(true), Inequality("true", "false"));
     }
 
     public void ShouldAssertNullableBools()
@@ -26,19 +26,30 @@ class BoolTests
         bool? nullableBool = null;
 
         nullableBool.ShouldBe(null);
-        Contradiction(nullableBool, x => x.ShouldBe(false), "x should be false but was null");
-        Contradiction(nullableBool, x => x.ShouldBe(true), "x should be true but was null");
+        Contradiction(nullableBool, x => x.ShouldBe(false), Inequality("false", "null"));
+        Contradiction(nullableBool, x => x.ShouldBe(true), Inequality("true", "null"));
 
         nullableBool = false;
 
-        Contradiction(nullableBool, x => x.ShouldBe(null), "x should be null but was false");
+        Contradiction(nullableBool, x => x.ShouldBe(null), Inequality("null", "false"));
         nullableBool.ShouldBe(false);
-        Contradiction(nullableBool, x => x.ShouldBe(true), "x should be true but was false");
+        Contradiction(nullableBool, x => x.ShouldBe(true), Inequality("true", "false"));
 
         nullableBool = true;
 
-        Contradiction(nullableBool, x => x.ShouldBe(null), "x should be null but was true");
-        Contradiction(nullableBool, x => x.ShouldBe(false), "x should be false but was true");
+        Contradiction(nullableBool, x => x.ShouldBe(null), Inequality("null", "true"));
+        Contradiction(nullableBool, x => x.ShouldBe(false), Inequality("false", "true"));
         nullableBool.ShouldBe(true);
     }
+
+    static string Inequality(string expectedLiteral, string actualLiteral) =>
+        $"""
+         x should be
+
+             {expectedLiteral}
+
+         but was
+
+             {actualLiteral}
+         """;
 }

--- a/src/Fixie.Assertions.Tests/NumericTests.cs
+++ b/src/Fixie.Assertions.Tests/NumericTests.cs
@@ -59,100 +59,100 @@ class NumericTests
     {
         sbyte.MinValue.ShouldBe(sbyte.MinValue);
         sbyte.MaxValue.ShouldBe(sbyte.MaxValue);
-        Contradiction((sbyte)1, x => x.ShouldBe((sbyte)2), "x should be 2 but was 1");
+        Contradiction((sbyte)1, x => x.ShouldBe((sbyte)2), Inequality("2", "1"));
         ((sbyte?)null).ShouldBe(null);
-        Contradiction((sbyte?)null, x => x.ShouldBe((sbyte)1), "x should be 1 but was null");
-        Contradiction((sbyte?)1, x => x.ShouldBe(null), "x should be null but was 1");
+        Contradiction((sbyte?)null, x => x.ShouldBe((sbyte)1), Inequality("1", "null"));
+        Contradiction((sbyte?)1, x => x.ShouldBe(null), Inequality("null", "1"));
         
         byte.MinValue.ShouldBe(byte.MinValue);
         byte.MaxValue.ShouldBe(byte.MaxValue);
-        Contradiction((byte)2, x => x.ShouldBe((byte)3), "x should be 3 but was 2");
+        Contradiction((byte)2, x => x.ShouldBe((byte)3), Inequality("3", "2"));
         ((byte?)null).ShouldBe(null);
-        Contradiction((byte?)null, x => x.ShouldBe((byte)2), "x should be 2 but was null");
-        Contradiction((byte?)2, x => x.ShouldBe(null), "x should be null but was 2");
+        Contradiction((byte?)null, x => x.ShouldBe((byte)2), Inequality("2", "null"));
+        Contradiction((byte?)2, x => x.ShouldBe(null), Inequality("null", "2"));
         
         short.MinValue.ShouldBe(short.MinValue);
         short.MaxValue.ShouldBe(short.MaxValue);
-        Contradiction((short)3, x => x.ShouldBe((short)4), "x should be 4 but was 3");
+        Contradiction((short)3, x => x.ShouldBe((short)4), Inequality("4", "3"));
         ((short?)null).ShouldBe(null);
-        Contradiction((short?)null, x => x.ShouldBe((short)3), "x should be 3 but was null");
-        Contradiction((short?)3, x => x.ShouldBe(null), "x should be null but was 3");
+        Contradiction((short?)null, x => x.ShouldBe((short)3), Inequality("3", "null"));
+        Contradiction((short?)3, x => x.ShouldBe(null), Inequality("null", "3"));
         
         ushort.MinValue.ShouldBe(ushort.MinValue);
         ushort.MaxValue.ShouldBe(ushort.MaxValue);
-        Contradiction((ushort)4, x => x.ShouldBe((ushort)5), "x should be 5 but was 4");
+        Contradiction((ushort)4, x => x.ShouldBe((ushort)5), Inequality("5", "4"));
         ((ushort?)null).ShouldBe(null);
-        Contradiction((ushort?)null, x => x.ShouldBe((ushort)4), "x should be 4 but was null");
-        Contradiction((ushort?)4, x => x.ShouldBe(null), "x should be null but was 4");
+        Contradiction((ushort?)null, x => x.ShouldBe((ushort)4), Inequality("4", "null"));
+        Contradiction((ushort?)4, x => x.ShouldBe(null), Inequality("null", "4"));
 
         int.MinValue.ShouldBe(int.MinValue);
         int.MaxValue.ShouldBe(int.MaxValue);
-        Contradiction((int)5, x => x.ShouldBe((int)6), "x should be 6 but was 5");
+        Contradiction((int)5, x => x.ShouldBe((int)6), Inequality("6", "5"));
         ((int?)null).ShouldBe(null);
-        Contradiction((int?)null, x => x.ShouldBe((int)5), "x should be 5 but was null");
-        Contradiction((int?)5, x => x.ShouldBe(null), "x should be null but was 5");
+        Contradiction((int?)null, x => x.ShouldBe((int)5), Inequality("5", "null"));
+        Contradiction((int?)5, x => x.ShouldBe(null), Inequality("null", "5"));
 
         uint.MinValue.ShouldBe(uint.MinValue);
         uint.MaxValue.ShouldBe(uint.MaxValue);
-        Contradiction((uint)6, x => x.ShouldBe((uint)7), "x should be 7 but was 6");
+        Contradiction((uint)6, x => x.ShouldBe((uint)7), Inequality("7", "6"));
         ((uint?)null).ShouldBe(null);
-        Contradiction((uint?)null, x => x.ShouldBe((uint)6), "x should be 6 but was null");
-        Contradiction((uint?)6, x => x.ShouldBe(null), "x should be null but was 6");
+        Contradiction((uint?)null, x => x.ShouldBe((uint)6), Inequality("6", "null"));
+        Contradiction((uint?)6, x => x.ShouldBe(null), Inequality("null", "6"));
         
         long.MinValue.ShouldBe(long.MinValue);
         long.MaxValue.ShouldBe(long.MaxValue);
-        Contradiction((long)7, x => x.ShouldBe((long)8), "x should be 8 but was 7");
+        Contradiction((long)7, x => x.ShouldBe((long)8), Inequality("8", "7"));
         ((long?)null).ShouldBe(null);
-        Contradiction((long?)null, x => x.ShouldBe((long)7), "x should be 7 but was null");
-        Contradiction((long?)7, x => x.ShouldBe(null), "x should be null but was 7");
+        Contradiction((long?)null, x => x.ShouldBe((long)7), Inequality("7", "null"));
+        Contradiction((long?)7, x => x.ShouldBe(null), Inequality("null", "7"));
 
         ulong.MinValue.ShouldBe(ulong.MinValue);
         ulong.MaxValue.ShouldBe(ulong.MaxValue);
-        Contradiction((ulong)8, x => x.ShouldBe((ulong)9), "x should be 9 but was 8");
+        Contradiction((ulong)8, x => x.ShouldBe((ulong)9), Inequality("9", "8"));
         ((ulong?)null).ShouldBe(null);
-        Contradiction((ulong?)null, x => x.ShouldBe((ulong)8), "x should be 8 but was null");
-        Contradiction((ulong?)8, x => x.ShouldBe(null), "x should be null but was 8");
+        Contradiction((ulong?)null, x => x.ShouldBe((ulong)8), Inequality("8", "null"));
+        Contradiction((ulong?)8, x => x.ShouldBe(null), Inequality("null", "8"));
     }
 
     public void ShouldAssertNativeIntegralNumbers()
     {
         nint.MinValue.ShouldBe(nint.MinValue);
         nint.MaxValue.ShouldBe(nint.MaxValue);
-        Contradiction((nint)9, x => x.ShouldBe((nint)10), "x should be 10 but was 9");
+        Contradiction((nint)9, x => x.ShouldBe((nint)10), Inequality("10", "9"));
         ((nint?)null).ShouldBe(null);
-        Contradiction((nint?)null, x => x.ShouldBe((nint)9), "x should be 9 but was null");
-        Contradiction((nint?)9, x => x.ShouldBe(null), "x should be null but was 9");
+        Contradiction((nint?)null, x => x.ShouldBe((nint)9), Inequality("9", "null"));
+        Contradiction((nint?)9, x => x.ShouldBe(null), Inequality("null", "9"));
 
         nuint.MinValue.ShouldBe(nuint.MinValue);
         nuint.MaxValue.ShouldBe(nuint.MaxValue);
-        Contradiction((nuint)10, x => x.ShouldBe((nuint)11), "x should be 11 but was 10");
+        Contradiction((nuint)10, x => x.ShouldBe((nuint)11), Inequality("11", "10"));
         ((nuint?)null).ShouldBe(null);
-        Contradiction((nuint?)null, x => x.ShouldBe((nuint)10), "x should be 10 but was null");
-        Contradiction((nuint?)10, x => x.ShouldBe(null), "x should be null but was 10");
+        Contradiction((nuint?)null, x => x.ShouldBe((nuint)10), Inequality("10", "null"));
+        Contradiction((nuint?)10, x => x.ShouldBe(null), Inequality("null", "10"));
     }
 
     public void ShouldAssertFractionalNumbers()
     {
         decimal.MinValue.ShouldBe(decimal.MinValue);
         decimal.MaxValue.ShouldBe(decimal.MaxValue);
-        Contradiction((decimal)1, x => x.ShouldBe((decimal)2), "x should be 2 but was 1");
+        Contradiction((decimal)1, x => x.ShouldBe((decimal)2), Inequality("2", "1"));
         ((decimal?)null).ShouldBe(null);
-        Contradiction((decimal?)null, x => x.ShouldBe((decimal)1), "x should be 1 but was null");
-        Contradiction((decimal?)1, x => x.ShouldBe(null), "x should be null but was 1");
+        Contradiction((decimal?)null, x => x.ShouldBe((decimal)1), Inequality("1", "null"));
+        Contradiction((decimal?)1, x => x.ShouldBe(null), Inequality("null", "1"));
 
         double.MinValue.ShouldBe(double.MinValue);
         double.MaxValue.ShouldBe(double.MaxValue);
-        Contradiction((double)2, x => x.ShouldBe((double)3), "x should be 3 but was 2");
+        Contradiction((double)2, x => x.ShouldBe((double)3), Inequality("3", "2"));
         ((double?)null).ShouldBe(null);
-        Contradiction((double?)null, x => x.ShouldBe((double)2), "x should be 2 but was null");
-        Contradiction((double?)2, x => x.ShouldBe(null), "x should be null but was 2");
+        Contradiction((double?)null, x => x.ShouldBe((double)2), Inequality("2", "null"));
+        Contradiction((double?)2, x => x.ShouldBe(null), Inequality("null", "2"));
 
         float.MinValue.ShouldBe(float.MinValue);
         float.MaxValue.ShouldBe(float.MaxValue);
-        Contradiction((float)3, x => x.ShouldBe((float)4), "x should be 4 but was 3");
+        Contradiction((float)3, x => x.ShouldBe((float)4), Inequality("4", "3"));
         ((float?)null).ShouldBe(null);
-        Contradiction((float?)null, x => x.ShouldBe((float)3), "x should be 3 but was null");
-        Contradiction((float?)3, x => x.ShouldBe(null), "x should be null but was 3");
+        Contradiction((float?)null, x => x.ShouldBe((float)3), Inequality("3", "null"));
+        Contradiction((float?)3, x => x.ShouldBe(null), Inequality("null", "3"));
     }
 
     static void VerifySerialization<T>(string expectedMin, string expectedMax) where T : struct, INumber<T>
@@ -180,4 +180,15 @@ class NumericTests
 
         return (T)minValue;
     }
+
+    static string Inequality(string expectedLiteral, string actualLiteral) =>
+        $"""
+         x should be
+
+             {expectedLiteral}
+
+         but was
+
+             {actualLiteral}
+         """;
 }

--- a/src/Fixie.Assertions.Tests/StackTraceTests.cs
+++ b/src/Fixie.Assertions.Tests/StackTraceTests.cs
@@ -25,7 +25,17 @@ class StackTraceTests
     {
         var exception = Catch(FailAssertion);
         
-        exception.Message.ShouldBe("1 should be 2 but was 1");
+        exception.Message
+            .ShouldBe(
+                """
+                1 should be
+                
+                    2
+                
+                but was
+                
+                    1
+                """);
 
         exception.StackTrace.ShouldNotBeNull();
         

--- a/src/Fixie.Assertions.Tests/TextTests.cs
+++ b/src/Fixie.Assertions.Tests/TextTests.cs
@@ -441,11 +441,38 @@ class TextTests
     public void ShouldAssertChars()
     {
         'a'.ShouldBe('a');
-        Contradiction('a', x => x.ShouldBe('z'), "x should be 'z' but was 'a'");
+        Contradiction('a', x => x.ShouldBe('z'),
+            """
+            x should be
+            
+                'z'
+            
+            but was
+            
+                'a'
+            """);
 
         ((char?)null).ShouldBe(null);
-        Contradiction((char?)null, x => x.ShouldBe('z'), "x should be 'z' but was null");
-        Contradiction((char?)'a', x => x.ShouldBe(null), "x should be null but was 'a'");
+        Contradiction((char?)null, x => x.ShouldBe('z'),
+            """
+            x should be
+            
+                'z'
+            
+            but was
+            
+                null
+            """);
+        Contradiction((char?)'a', x => x.ShouldBe(null),
+            """
+            x should be
+            
+                null
+            
+            but was
+            
+                'a'
+            """);
     }
 
     public void ShouldAssertStrings()

--- a/src/Fixie.Assertions.Tests/ThrownExceptionTests.cs
+++ b/src/Fixie.Assertions.Tests/ThrownExceptionTests.cs
@@ -54,9 +54,9 @@ class ThrownExceptionTests
         var funcReturingNullableInt = () => (int?)1;
         var funcReturningStruct = () => new Struct();
 
-        Contradiction(funcReturingBool, x => x.ShouldThrow<Exception>(), DelegateMisused<Func<bool>>());
-        Contradiction(funcReturingNullableInt, x => x.ShouldThrow<Exception>(), DelegateMisused<Func<int?>>());
-        Contradiction(funcReturningStruct, x => x.ShouldThrow<Exception>(), DelegateMisused<Func<Struct>>());
+        Contradiction(funcReturingBool, x => x.ShouldThrow<Exception>(), DelegateMisused("Func<bool>"));
+        Contradiction(funcReturingNullableInt, x => x.ShouldThrow<Exception>(), DelegateMisused("Func<int?>"));
+        Contradiction(funcReturningStruct, x => x.ShouldThrow<Exception>(), DelegateMisused("Func<Tests.ThrownExceptionTests.Struct>"));
 
 
         // Valid overloads for these function types exist, so if we encounter them as
@@ -68,10 +68,10 @@ class ThrownExceptionTests
         Func<Task> funcTaskAsync = async () => await Task.CompletedTask;
         Func<Task<int>> funcTaskResultAsync = async () => await Task.FromResult(1);
 
-        Contradiction((Delegate)action, x => x.ShouldThrow<Exception>(), DelegateMisused<Action>());
-        Contradiction((Delegate)funcReturningReference, x => x.ShouldThrow<Exception>(), DelegateMisused<Func<string>>());
-        Contradiction((Delegate)funcTaskAsync, x => x.ShouldThrow<Exception>(), DelegateMisused<Func<Task>>());
-        Contradiction((Delegate)funcTaskResultAsync, x => x.ShouldThrow<Exception>(), DelegateMisused<Func<Task<int>>>());
+        Contradiction((Delegate)action, x => x.ShouldThrow<Exception>(), DelegateMisused("Action"));
+        Contradiction((Delegate)funcReturningReference, x => x.ShouldThrow<Exception>(), DelegateMisused("Func<string>"));
+        Contradiction((Delegate)funcTaskAsync, x => x.ShouldThrow<Exception>(), DelegateMisused("Func<System.Threading.Tasks.Task>"));
+        Contradiction((Delegate)funcTaskResultAsync, x => x.ShouldThrow<Exception>(), DelegateMisused("Func<System.Threading.Tasks.Task<int>>"));
 
 
         // We'd prefer to just let the user encounter a simple compiler error
@@ -86,11 +86,11 @@ class ThrownExceptionTests
         Func<int, string, int> funcWithInputs = (int x, string y) => x;
         Func<ValueTask> funcValueTaskAsync = async () => await Task.CompletedTask;
 
-        Contradiction(actionWithInput, x => x.ShouldThrow<Exception>(), DelegateMisused<Action<int>>());
-        Contradiction(actionWithInputs, x => x.ShouldThrow<Exception>(), DelegateMisused<Action<int, string>>());
-        Contradiction(funcWithInput, x => x.ShouldThrow<Exception>(), DelegateMisused<Func<int, int>>());
-        Contradiction(funcWithInputs, x => x.ShouldThrow<Exception>(), DelegateMisused<Func<int, string, int>>());
-        Contradiction(funcValueTaskAsync, x => x.ShouldThrow<Exception>(), DelegateMisused<Func<ValueTask>>());
+        Contradiction(actionWithInput, x => x.ShouldThrow<Exception>(), DelegateMisused("Action<int>"));
+        Contradiction(actionWithInputs, x => x.ShouldThrow<Exception>(), DelegateMisused("Action<int, string>"));
+        Contradiction(funcWithInput, x => x.ShouldThrow<Exception>(), DelegateMisused("Func<int, int>"));
+        Contradiction(funcWithInputs, x => x.ShouldThrow<Exception>(), DelegateMisused("Func<int, string, int>"));
+        Contradiction(funcValueTaskAsync, x => x.ShouldThrow<Exception>(), DelegateMisused("Func<System.Threading.Tasks.ValueTask>"));
     }
 
     public void DetectPotentialForSimplification()
@@ -313,11 +313,11 @@ class ThrownExceptionTests
             "Simulated Failure"
         """;
 
-    static string DelegateMisused<TResult>() =>
+    static string DelegateMisused(string expectedFunctionType) =>
         $"""
          x has a function type compatible with
 
-             {typeof(TResult)}
+             {expectedFunctionType}
 
          but ShouldThrow<TException> has no corresponding overload.
 

--- a/src/Fixie.Assertions.Tests/TypeTests.cs
+++ b/src/Fixie.Assertions.Tests/TypeTests.cs
@@ -28,40 +28,45 @@ class TypeTests
         Serialize(typeof(Guid?)).ShouldBe("typeof(System.Guid?)");
         Serialize(typeof(int?)).ShouldBe("typeof(int?)");
 
-        Serialize(typeof(Sample)).ShouldBe("typeof(Tests.TypeTests+Sample)");
+        Serialize(typeof(Sample)).ShouldBe("typeof(Tests.TypeTests.Sample)");
         
         Serialize(typeof(Tests.TypeTests.Outermost<>))
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1[TOuter])");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<>)");
         Serialize(typeof(Tests.TypeTests.Outermost<Tests.TypeTests.Sample>))
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1[Tests.TypeTests+Sample])");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<Tests.TypeTests.Sample>)");
         Serialize(typeof(Tests.TypeTests.Outermost<int>))
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1[System.Int32])");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<int>)");
 
         Serialize(typeof(Tests.TypeTests.Outermost<>.Inner<>))
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1[TOuter,TInner])");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<>.Inner<>)");
         Serialize(typeof(Tests.TypeTests.Outermost<Tests.TypeTests.Sample>.Inner<int>))
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1[Tests.TypeTests+Sample,System.Int32])");
-        Serialize(typeof(Tests.TypeTests.Outermost<Tests.TypeTests.Sample>.Inner<Outermost<Tests.TypeTests.Sample>.Inner<int>>))
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1[Tests.TypeTests+Sample,Tests.TypeTests+Outermost`1+Inner`1[Tests.TypeTests+Sample,System.Int32]])");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<Tests.TypeTests.Sample>.Inner<int>)");
+        Serialize(typeof(Tests.TypeTests.Outermost<Tests.TypeTests.Sample>.Inner<Tests.TypeTests.Outermost<Tests.TypeTests.Sample>.Inner<int>>))
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<Tests.TypeTests.Sample>.Inner<Tests.TypeTests.Outermost<Tests.TypeTests.Sample>.Inner<int>>)");
 
         Serialize(typeof(Tests.TypeTests.Outermost<>.Inner<>.Innermost<>))
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1+Innermost`1[TOuter,TInner,TimeSpan])");
-        Serialize(typeof(Tests.TypeTests.Outermost<>.Inner<>.Innermost<>))
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1+Innermost`1[TOuter,TInner,TimeSpan])");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<>.Inner<>.Innermost<>)");
         Serialize(typeof(Tests.TypeTests.Outermost<bool>.Inner<Tests.TypeTests.Sample>.Innermost<string>))
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1+Innermost`1[System.Boolean,Tests.TypeTests+Sample,System.String])");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<bool>.Inner<Tests.TypeTests.Sample>.Innermost<string>)");
         Serialize(typeof(Tests.TypeTests.Outermost<Tests.TypeTests.Outermost<System.TimeSpan>.Inner<Tests.TypeTests.Sample>>.Inner<Tests.TypeTests.Outermost<bool>.Inner<Tests.TypeTests.Sample>.Innermost<TimeSpan>>.Innermost<Tests.TypeTests.Outermost<Tests.TypeTests.Sample>.Inner<int>>))
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1+Innermost`1[Tests.TypeTests+Outermost`1+Inner`1[System.TimeSpan,Tests.TypeTests+Sample],Tests.TypeTests+Outermost`1+Inner`1+Innermost`1[System.Boolean,Tests.TypeTests+Sample,System.TimeSpan],Tests.TypeTests+Outermost`1+Inner`1[Tests.TypeTests+Sample,System.Int32]])");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<Tests.TypeTests.Outermost<System.TimeSpan>.Inner<Tests.TypeTests.Sample>>.Inner<Tests.TypeTests.Outermost<bool>.Inner<Tests.TypeTests.Sample>.Innermost<System.TimeSpan>>.Innermost<Tests.TypeTests.Outermost<Tests.TypeTests.Sample>.Inner<int>>)");
 
         Serialize(typeof(Tests.TypeTests.Outermost<>.InnerEnum))
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+InnerEnum[TOuter])");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<>.InnerEnum)");
         Serialize(typeof(Tests.TypeTests.Outermost<int>.InnerEnum))
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+InnerEnum[System.Int32])");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<int>.InnerEnum)");
 
         Serialize(typeof(Tests.TypeTests.Outermost<>.InnerTwo<,>))
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+InnerTwo`2[TOuter,T1,T2])");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<>.InnerTwo<,>)");
         Serialize(typeof(Tests.TypeTests.Outermost<int>.InnerTwo<bool,string>))
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+InnerTwo`2[System.Int32,System.Boolean,System.String])");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<int>.InnerTwo<bool,string>)");
+
+        Serialize(typeof(Tests.TypeTests.Outermost<>.Nongeneric))
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<>.Nongeneric)");
+        Serialize(typeof(Tests.TypeTests.Outermost<>.Nongeneric.MoreGeneric<>))
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<>.Nongeneric.MoreGeneric<>)");
+        Serialize(typeof(Tests.TypeTests.Outermost<string>.Nongeneric.MoreGeneric<int>))
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<string>.Nongeneric.MoreGeneric<int>)");            
 
         // Somewhat surprising, but demonstrates we either have ALL generic
         // type parameters or else ALL specified with concrete types.
@@ -69,12 +74,12 @@ class TypeTests
         var innerTwoOpen = outerSpecified.GetNestedType("InnerTwo`2");
         innerTwoOpen.ShouldNotBeNull();
         Serialize(innerTwoOpen)
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+InnerTwo`2[TOuter,T1,T2])");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<>.InnerTwo<,>)");
 
         // MakeGenericType insists all three be provided.
         var innerTwoSpecified = innerTwoOpen.MakeGenericType(typeof(int), typeof(bool), typeof(string));
         Serialize(innerTwoSpecified)
-            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+InnerTwo`2[System.Int32,System.Boolean,System.String])");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<int>.InnerTwo<bool,string>)");
     }
 
     public void ShouldAssertTypeEquality()
@@ -158,7 +163,7 @@ class TypeTests
              
              but was
              
-                 Tests.TypeTests+Sample
+                 Tests.TypeTests.Sample
              """);
         Contradiction(true, x => x.ShouldBe<GeneralAssertionTests>(),
             $"""
@@ -241,6 +246,13 @@ class TypeTests
 
         public enum InnerEnum
         {
+        }
+
+        public class Nongeneric
+        {
+            public class MoreGeneric<TMore>
+            {
+            }
         }
     }
 }

--- a/src/Fixie.Assertions.Tests/TypeTests.cs
+++ b/src/Fixie.Assertions.Tests/TypeTests.cs
@@ -1,4 +1,4 @@
-namespace Tests;
+﻿namespace Tests;
 
 class TypeTests
 {
@@ -27,6 +27,31 @@ class TypeTests
 
         Serialize(typeof(Guid?)).ShouldBe("typeof(System.Guid?)");
         Serialize(typeof(int?)).ShouldBe("typeof(int?)");
+
+        Serialize(typeof(Sample)).ShouldBe("typeof(Tests.TypeTests+Sample)");
+        
+        Serialize(typeof(Tests.TypeTests.Outermost<>))
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1[TOuter])");
+        Serialize(typeof(Tests.TypeTests.Outermost<Tests.TypeTests.Sample>))
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1[Tests.TypeTests+Sample])");
+        Serialize(typeof(Tests.TypeTests.Outermost<int>))
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1[System.Int32])");
+
+        Serialize(typeof(Tests.TypeTests.Outermost<>.Inner<>))
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1[TOuter,TInner])");
+        Serialize(typeof(Tests.TypeTests.Outermost<Tests.TypeTests.Sample>.Inner<int>))
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1[Tests.TypeTests+Sample,System.Int32])");
+        Serialize(typeof(Tests.TypeTests.Outermost<Tests.TypeTests.Sample>.Inner<Outermost<Tests.TypeTests.Sample>.Inner<int>>))
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1[Tests.TypeTests+Sample,Tests.TypeTests+Outermost`1+Inner`1[Tests.TypeTests+Sample,System.Int32]])");
+
+        Serialize(typeof(Tests.TypeTests.Outermost<>.Inner<>.Innermost<>))
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1+Innermost`1[TOuter,TInner,TimeSpan])");
+        Serialize(typeof(Tests.TypeTests.Outermost<>.Inner<>.Innermost<>))
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1+Innermost`1[TOuter,TInner,TimeSpan])");
+        Serialize(typeof(Tests.TypeTests.Outermost<bool>.Inner<Tests.TypeTests.Sample>.Innermost<string>))
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1+Innermost`1[System.Boolean,Tests.TypeTests+Sample,System.String])");
+        Serialize(typeof(Tests.TypeTests.Outermost<Tests.TypeTests.Outermost<System.TimeSpan>.Inner<Tests.TypeTests.Sample>>.Inner<Tests.TypeTests.Outermost<bool>.Inner<Tests.TypeTests.Sample>.Innermost<TimeSpan>>.Innermost<Tests.TypeTests.Outermost<Tests.TypeTests.Sample>.Inner<int>>))
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1+Innermost`1[Tests.TypeTests+Outermost`1+Inner`1[System.TimeSpan,Tests.TypeTests+Sample],Tests.TypeTests+Outermost`1+Inner`1+Innermost`1[System.Boolean,Tests.TypeTests+Sample,System.TimeSpan],Tests.TypeTests+Outermost`1+Inner`1[Tests.TypeTests+Sample,System.Int32]])");
     }
 
     public void ShouldAssertTypeEquality()
@@ -175,4 +200,16 @@ class TypeTests
     }
 
     class Sample;
+
+    class Outermost<TOuter>
+    {
+        public class Inner<TInner>
+        {
+            // Deliberately confusing type parameter name to ensure it doesn't
+            // arrive in serialized output even while System.TimeSpan does.
+            public class Innermost<TimeSpan>
+            {
+            }
+        }
+    }
 }

--- a/src/Fixie.Assertions.Tests/TypeTests.cs
+++ b/src/Fixie.Assertions.Tests/TypeTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Tests;
+namespace Tests;
 
 class TypeTests
 {
@@ -37,7 +37,7 @@ class TypeTests
             $"""
              x should be
 
-                 typeof({FullName<GeneralAssertionTests>()})
+                 typeof(Tests.GeneralAssertionTests)
              
              but was
              
@@ -47,7 +47,7 @@ class TypeTests
             $"""
              x should be
              
-                 typeof({FullName<GeneralAssertionTests>()})
+                 typeof(Tests.GeneralAssertionTests)
              
              but was
              
@@ -58,7 +58,7 @@ class TypeTests
             $"""
              x should be
              
-                 typeof({FullName<GeneralAssertionTests>()})
+                 typeof(Tests.GeneralAssertionTests)
              
              but was
              
@@ -72,7 +72,7 @@ class TypeTests
              
              but was
              
-                 typeof({FullName<GeneralAssertionTests>()})
+                 typeof(Tests.GeneralAssertionTests)
              """);
 
         Contradiction((Type?)null, x => x.ShouldBe(typeof(object)),
@@ -106,17 +106,17 @@ class TypeTests
             $"""
              x should match the type pattern
              
-                 is {FullName<GeneralAssertionTests>()}
+                 is Tests.GeneralAssertionTests
              
              but was
              
-                 {FullName<Sample>()}
+                 Tests.TypeTests+Sample
              """);
         Contradiction(true, x => x.ShouldBe<GeneralAssertionTests>(),
             $"""
              x should match the type pattern
              
-                 is {FullName<GeneralAssertionTests>()}
+                 is Tests.GeneralAssertionTests
              
              but was
              
@@ -127,7 +127,7 @@ class TypeTests
             $"""
              x should match the type pattern
              
-                 is {FullName<GeneralAssertionTests>()}
+                 is Tests.GeneralAssertionTests
              
              but was
              
@@ -140,7 +140,7 @@ class TypeTests
             $"""
              x should match the type pattern
              
-                 is {FullName<GeneralAssertionTests>()}
+                 is Tests.GeneralAssertionTests
              
              but was
              
@@ -150,7 +150,7 @@ class TypeTests
             $"""
              x should match the type pattern
 
-                 is {FullName<GeneralAssertionTests>()}
+                 is Tests.GeneralAssertionTests
              
              but was
 
@@ -160,7 +160,7 @@ class TypeTests
             $"""
              x should match the type pattern
 
-                 is {FullName<GeneralAssertionTests>()}
+                 is Tests.GeneralAssertionTests
 
              but was
 

--- a/src/Fixie.Assertions.Tests/TypeTests.cs
+++ b/src/Fixie.Assertions.Tests/TypeTests.cs
@@ -52,6 +52,29 @@ class TypeTests
             .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1+Innermost`1[System.Boolean,Tests.TypeTests+Sample,System.String])");
         Serialize(typeof(Tests.TypeTests.Outermost<Tests.TypeTests.Outermost<System.TimeSpan>.Inner<Tests.TypeTests.Sample>>.Inner<Tests.TypeTests.Outermost<bool>.Inner<Tests.TypeTests.Sample>.Innermost<TimeSpan>>.Innermost<Tests.TypeTests.Outermost<Tests.TypeTests.Sample>.Inner<int>>))
             .ShouldBe("typeof(Tests.TypeTests+Outermost`1+Inner`1+Innermost`1[Tests.TypeTests+Outermost`1+Inner`1[System.TimeSpan,Tests.TypeTests+Sample],Tests.TypeTests+Outermost`1+Inner`1+Innermost`1[System.Boolean,Tests.TypeTests+Sample,System.TimeSpan],Tests.TypeTests+Outermost`1+Inner`1[Tests.TypeTests+Sample,System.Int32]])");
+
+        Serialize(typeof(Tests.TypeTests.Outermost<>.InnerEnum))
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+InnerEnum[TOuter])");
+        Serialize(typeof(Tests.TypeTests.Outermost<int>.InnerEnum))
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+InnerEnum[System.Int32])");
+
+        Serialize(typeof(Tests.TypeTests.Outermost<>.InnerTwo<,>))
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+InnerTwo`2[TOuter,T1,T2])");
+        Serialize(typeof(Tests.TypeTests.Outermost<int>.InnerTwo<bool,string>))
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+InnerTwo`2[System.Int32,System.Boolean,System.String])");
+
+        // Somewhat surprising, but demonstrates we either have ALL generic
+        // type parameters or else ALL specified with concrete types.
+        var outerSpecified = typeof(Tests.TypeTests.Outermost<int>);
+        var innerTwoOpen = outerSpecified.GetNestedType("InnerTwo`2");
+        innerTwoOpen.ShouldNotBeNull();
+        Serialize(innerTwoOpen)
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+InnerTwo`2[TOuter,T1,T2])");
+
+        // MakeGenericType insists all three be provided.
+        var innerTwoSpecified = innerTwoOpen.MakeGenericType(typeof(int), typeof(bool), typeof(string));
+        Serialize(innerTwoSpecified)
+            .ShouldBe("typeof(Tests.TypeTests+Outermost`1+InnerTwo`2[System.Int32,System.Boolean,System.String])");
     }
 
     public void ShouldAssertTypeEquality()
@@ -210,6 +233,14 @@ class TypeTests
             public class Innermost<TimeSpan>
             {
             }
+        }
+
+        public class InnerTwo<T1, T2>
+        {
+        }
+
+        public enum InnerEnum
+        {
         }
     }
 }

--- a/src/Fixie.Assertions.Tests/TypeTests.cs
+++ b/src/Fixie.Assertions.Tests/TypeTests.cs
@@ -58,15 +58,15 @@ class TypeTests
 
         Serialize(typeof(Tests.TypeTests.Outermost<>.InnerTwo<,>))
             .ShouldBe("typeof(Tests.TypeTests.Outermost<>.InnerTwo<,>)");
-        Serialize(typeof(Tests.TypeTests.Outermost<int>.InnerTwo<bool,string>))
-            .ShouldBe("typeof(Tests.TypeTests.Outermost<int>.InnerTwo<bool,string>)");
+        Serialize(typeof(Tests.TypeTests.Outermost<int>.InnerTwo<bool?,string>))
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<int>.InnerTwo<bool?, string>)");
 
         Serialize(typeof(Tests.TypeTests.Outermost<>.Nongeneric))
             .ShouldBe("typeof(Tests.TypeTests.Outermost<>.Nongeneric)");
         Serialize(typeof(Tests.TypeTests.Outermost<>.Nongeneric.MoreGeneric<>))
             .ShouldBe("typeof(Tests.TypeTests.Outermost<>.Nongeneric.MoreGeneric<>)");
-        Serialize(typeof(Tests.TypeTests.Outermost<string>.Nongeneric.MoreGeneric<int>))
-            .ShouldBe("typeof(Tests.TypeTests.Outermost<string>.Nongeneric.MoreGeneric<int>)");            
+        Serialize(typeof(Tests.TypeTests.Outermost<string>.Nongeneric.MoreGeneric<int?>))
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<string>.Nongeneric.MoreGeneric<int?>)");            
 
         // Somewhat surprising, but demonstrates we either have ALL generic
         // type parameters or else ALL specified with concrete types.
@@ -79,7 +79,7 @@ class TypeTests
         // MakeGenericType insists all three be provided.
         var innerTwoSpecified = innerTwoOpen.MakeGenericType(typeof(int), typeof(bool), typeof(string));
         Serialize(innerTwoSpecified)
-            .ShouldBe("typeof(Tests.TypeTests.Outermost<int>.InnerTwo<bool,string>)");
+            .ShouldBe("typeof(Tests.TypeTests.Outermost<int>.InnerTwo<bool, string>)");
     }
 
     public void ShouldAssertTypeEquality()

--- a/src/Fixie.Assertions.Tests/Utility.cs
+++ b/src/Fixie.Assertions.Tests/Utility.cs
@@ -8,12 +8,6 @@ static class Utility
 {
     static readonly string Line = NewLine + NewLine;
 
-    public static string FullName<T>()
-    {
-        return typeof(T).FullName ??
-               throw new Exception($"Expected type {typeof(T).Name} to have a non-null FullName.");
-    }
-
     public static void Contradiction<T>(T actual, Action<T> shouldThrow, string expectedMessage, [CallerArgumentExpression(nameof(shouldThrow))] string assertion = default!)
     {
         try

--- a/src/Fixie.Assertions.Tests/Utility.cs
+++ b/src/Fixie.Assertions.Tests/Utility.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using static System.Environment;
+using static Fixie.Assertions.StringUtilities;
 
 namespace Tests;
 
@@ -62,7 +63,7 @@ static class Utility
             $"\t{assertion}{Line}" +
             $"The actual value in question was:{Line}" +
             $"\t{actual}{Line}" +
-            $"The assertion threw {exception.GetType().FullName} with message:{Line}" +
+            $"The assertion threw {TypeName(exception.GetType())} with message:{Line}" +
             $"\t{exception.Message}");
     }
 

--- a/src/Fixie.Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Assertions/AssertionExtensions.cs
@@ -314,42 +314,24 @@ public static class AssertionExtensions
 
     static AssertException Failure(string expression, string expected, string actual, string shouldVerb)
     {
-        bool isMultiline = !IsTrivial(expected) || !IsTrivial(actual);
-
         var content = new StringBuilder();
 
         content.Append(expression);
         content.Append(" should ");
         content.Append(shouldVerb);
 
-        if (isMultiline)
-        {
-            content.AppendLine();
-            content.AppendLine();
-            content.Append(Indent(expected));
-            content.AppendLine();
-            content.AppendLine();
-        }
-        else
-        {
-            content.Append(' ');
-            content.Append(expected);
-            content.Append(' ');
-        }
+        content.AppendLine();
+        content.AppendLine();
+        content.Append(Indent(expected));
+        
+        content.AppendLine();
+        content.AppendLine();
 
         content.Append("but was");
 
-        if (isMultiline)
-        {
-            content.AppendLine();
-            content.AppendLine();
-            content.Append(Indent(actual));
-        }
-        else
-        {
-            content.Append(' ');
-            content.Append(actual);
-        }
+        content.AppendLine();
+        content.AppendLine();
+        content.Append(Indent(actual));
 
         if (expected == actual)
         {
@@ -362,14 +344,6 @@ public static class AssertionExtensions
 
         var message = content.ToString();
 
-        return new(expression, expected, actual, message, isMultiline);
-    }
-
-    static bool IsTrivial(string value)
-    {
-        return
-            value == "null" || value == "true" || value == "false" ||
-            value.StartsWith('\'') ||
-            (value.Length > 0 && char.IsDigit(value[0]));
+        return new(expression, expected, actual, message, true);
     }
 }

--- a/src/Fixie.Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Assertions/AssertionExtensions.cs
@@ -246,8 +246,8 @@ public static class AssertionExtensions
             return typed;
         }
 
-        var expectedType = typeof(TException).FullName!;
-        var actualType = actual.GetType().FullName!;
+        var expectedType = TypeName(typeof(TException));
+        var actualType = TypeName(actual.GetType());
 
         var failure =
             new Message()
@@ -263,7 +263,7 @@ public static class AssertionExtensions
 
     static void ShouldHaveThrown<TException>(string expression, string? expectedMessage) where TException : Exception
     {
-        var expectedType = typeof(TException).FullName!;
+        var expectedType = TypeName(typeof(TException));
 
         throw new AssertException(expression, expectedType, "no exception was thrown",
             new Message()

--- a/src/Fixie.Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Assertions/AssertionExtensions.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Reflection;
-using System.Text;
 using System.Text.RegularExpressions;
 using static Fixie.Assertions.Serializer;
 using static Fixie.Assertions.StringUtilities;
@@ -18,7 +17,23 @@ public static class AssertionExtensions
     public static void ShouldBe<T>(this T? actual, T? expected, [CallerArgumentExpression(nameof(actual))] string expression = default!)
     {
         if (!EqualityComparer<T>.Default.Equals(actual, expected))
-            throw EqualityFailure(expression, expected, actual);
+        {
+            string expectedStructure = Serialize(expected);
+            string actualStructure = Serialize(actual);
+
+            var failure = new Message()
+                .Write(expression, " should be")
+                .Block(expectedStructure)
+                .Write("but was")
+                .Block(actualStructure);
+
+            if (expectedStructure == actualStructure)
+                failure.Write(
+                    "These serialized values are identical. Did you mean to perform " +
+                    "a structural comparison with `ShouldMatch` instead?");
+
+            throw new AssertException(expression, expectedStructure, actualStructure, failure.ToString(), true);
+        }
     }
 
     /// <summary>
@@ -30,7 +45,16 @@ public static class AssertionExtensions
         if (actual is T typed)
             return typed;
 
-        throw TypeFailure(expression, typeof(T), actual?.GetType());
+        var expectedPattern = $"is {TypeName(typeof(T))}";
+        var actualTypeName = actual == null ? "null" : TypeName(actual.GetType());
+
+        throw new AssertException(expression, expectedPattern, actualTypeName,
+            new Message()
+                .Write(expression, " should match the type pattern")
+                .Block(expectedPattern)
+                .Write("but was")
+                .Block(actualTypeName)
+                .ToString(), true);
     }
 
     /// <summary>
@@ -53,7 +77,13 @@ public static class AssertionExtensions
         var expectedStructure = Serialize(expected);
 
         if (actualStructure != expectedStructure)
-            throw StructuralEqualityFailure(expression, expectedStructure, actualStructure);
+            throw new AssertException(expression, expectedStructure, actualStructure,
+                new Message()
+                    .Write(expression, " should match")
+                    .Block(expectedStructure)
+                    .Write("but was")
+                    .Block(actualStructure)
+                    .ToString(), true);
     }
 
     /// <summary>
@@ -207,15 +237,11 @@ public static class AssertionExtensions
         {
             if (expectedMessage != null && actual.Message != expectedMessage)
                 throw new AssertException(expression, expectedMessage, actual.Message,
-                        $"""
-                         {expression} should have thrown {typeof(TException).FullName} with message
-             
-                         {Indent(Serialize(expectedMessage))}
-             
-                         but instead the message was
-             
-                         {Indent(Serialize(actual.Message))}
-                         """, false);
+                    new Message()
+                        .ShouldHaveThrown<TException>(expression, expectedMessage)
+                        .Write("but instead the message was")
+                        .Serialize(actual.Message)
+                        .ToString(), false);
 
             return typed;
         }
@@ -223,52 +249,27 @@ public static class AssertionExtensions
         var expectedType = typeof(TException).FullName!;
         var actualType = actual.GetType().FullName!;
 
+        var failure =
+            new Message()
+                .ShouldHaveThrown<TException>(expression, expectedMessage)
+                .Write("but instead it threw ", actualType, " with message")
+                .Serialize(actual.Message);
+
         if (expectedMessage == null)
-        {
-            throw new AssertException(expression, expectedType, actualType,
-                $"""
-                 {expression} should have thrown {expectedType}
+            throw new AssertException(expression, expectedType, actualType, failure.ToString(), false);
 
-                 but instead it threw {actualType} with message
-
-                 {Indent(Serialize(actual.Message))}
-                 """, false);
-        }
-
-        throw new AssertException(expression, expectedMessage, actual.Message,
-            $"""
-             {expression} should have thrown {expectedType} with message
-
-             {Indent(Serialize(expectedMessage))}
-
-             but instead it threw {actualType} with message
-
-             {Indent(Serialize(actual.Message))}
-             """, false);
+        throw new AssertException(expression, expectedMessage, actual.Message, failure.ToString(), false);
     }
 
     static void ShouldHaveThrown<TException>(string expression, string? expectedMessage) where TException : Exception
     {
         var expectedType = typeof(TException).FullName!;
 
-        if (expectedMessage == null)
-        {
-            throw new AssertException(expression, expectedType, "no exception was thrown",
-                $"""
-                 {expression} should have thrown {expectedType}
-
-                 but no exception was thrown.
-                 """, false);
-        }
-
         throw new AssertException(expression, expectedType, "no exception was thrown",
-            $"""
-             {expression} should have thrown {expectedType} with message
-
-             {Indent(Serialize(expectedMessage))}
-             
-             but no exception was thrown.
-             """, false);
+            new Message()
+                .ShouldHaveThrown<TException>(expression, expectedMessage)
+                .Write("but no exception was thrown.")
+                .ToString(), false);
     }
 
     /// <summary>
@@ -281,7 +282,15 @@ public static class AssertionExtensions
         {
             expectationBody = DropTrivialLambdaPrefix(expectationBody);
 
-            throw ExpectationFailure(expression, expectationBody, actual);
+            var actualStructure = Serialize(actual);
+
+            var failure = new Message()
+                .Write(expression, " should satisfy")
+                .Block(expectationBody)
+                .Write("but was")
+                .Block(actualStructure);
+
+            throw new AssertException(expression, expectationBody, actualStructure, failure.ToString(), true);
         }
     }
 
@@ -299,54 +308,4 @@ public static class AssertionExtensions
 
         return expectationBody;
     }
-
-    static AssertException EqualityFailure<T>(string expression, T expected, T actual)
-        => Failure(expression, Serialize(expected), Serialize(actual), "be");
-
-    static AssertException TypeFailure(string expression, Type expected, Type? actual)
-        => Failure(expression, $"is {TypeName(expected)}", actual == null ? "null" : TypeName(actual), "match the type pattern");
-
-    static AssertException StructuralEqualityFailure(string expression, string expectedStructure, string actualStructure)
-        => Failure(expression, expectedStructure, actualStructure, "match");
-
-    static AssertException ExpectationFailure<T>(string expression, string expectationBody, T actual)
-        => Failure(expression, expectationBody, Serialize(actual), "satisfy");
-
-    static AssertException Failure(string expression, string expected, string actual, string shouldVerb)
-    {
-        var content = new StringBuilder();
-
-        content.Append(expression);
-        content.Append(" should ");
-        content.Append(shouldVerb);
-
-        content.AppendLine();
-        content.AppendLine();
-        content.Append(Indent(expected));
-        
-        content.AppendLine();
-        content.AppendLine();
-
-        content.Append("but was");
-
-        content.AppendLine();
-        content.AppendLine();
-        content.Append(Indent(actual));
-
-        if (expected == actual)
-        {
-            content.AppendLine();
-            content.AppendLine();
-            content.Append(
-                "These serialized values are identical. Did you mean to perform " +
-                "a structural comparison with `ShouldMatch` instead?");
-        }
-
-        var message = content.ToString();
-
-        return new(expression, expected, actual, message, true);
-    }
-
-    static string Indent(string multiline) =>
-        string.Join(Environment.NewLine, multiline.Split(Environment.NewLine).Select(x => $"    {x}"));
 }

--- a/src/Fixie.Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Assertions/AssertionExtensions.cs
@@ -346,4 +346,7 @@ public static class AssertionExtensions
 
         return new(expression, expected, actual, message, true);
     }
+
+    static string Indent(string multiline) =>
+        string.Join(Environment.NewLine, multiline.Split(Environment.NewLine).Select(x => $"    {x}"));
 }

--- a/src/Fixie.Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Assertions/AssertionExtensions.cs
@@ -224,11 +224,11 @@ public static class AssertionExtensions
 
         if (function.ReturnType == typeof(void))
             return typeParameters.Count == 0
-                ? "System.Action"
-                : $"System.Action`{typeParameters.Count}[{string.Join(",", typeParameters)}]";
+                ? "Action"
+                : $"Action<{string.Join(", ", typeParameters.Select(TypeName))}>";
 
         typeParameters.Add(function.ReturnType);
-        return $"System.Func`{typeParameters.Count}[{string.Join(",", typeParameters)}]";
+        return $"Func<{string.Join(", ", typeParameters.Select(TypeName))}>";
     }
 
     static TException ShouldBeException<TException>(string? expectedMessage, string expression, Exception actual) where TException : Exception

--- a/src/Fixie.Assertions/Message.cs
+++ b/src/Fixie.Assertions/Message.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using static Fixie.Assertions.StringUtilities;
 
 namespace Fixie.Assertions;
 
@@ -49,7 +50,7 @@ class Message
 
     public Message ShouldHaveThrown<TException>(string expression, string? expectedMessage) where TException : Exception
     {
-        var expectedType = typeof(TException).FullName!;
+        var expectedType = TypeName(typeof(TException));
 
         Write(expression, " should have thrown ", expectedType);
 

--- a/src/Fixie.Assertions/Message.cs
+++ b/src/Fixie.Assertions/Message.cs
@@ -1,0 +1,74 @@
+﻿using System.Text;
+
+namespace Fixie.Assertions;
+
+class Message
+{
+    readonly StringBuilder output = new();
+
+    bool endsWithBlock = false;
+
+    public Message Write(params string[] parts)
+    {
+        if (endsWithBlock)
+            Blank();
+
+        foreach (var part in parts)
+            output.Append(part);
+
+        endsWithBlock = false;
+
+        return this;
+    }
+
+    public Message Block(string callout)
+    {
+        Blank();
+        output.Append(Indent(callout));
+
+        endsWithBlock = true;
+
+        return this;
+    }
+
+    public Message Blank()
+    {
+        output.AppendLine();
+        output.AppendLine();
+
+        endsWithBlock = false;
+
+        return this;
+    }
+
+    public Message Serialize<T>(T value)
+    {
+        Block(Serializer.Serialize(value));
+        return this;
+    }
+
+    public Message ShouldHaveThrown<TException>(string expression, string? expectedMessage) where TException : Exception
+    {
+        var expectedType = typeof(TException).FullName!;
+
+        Write(expression, " should have thrown ", expectedType);
+
+        if (expectedMessage == null)
+        {
+            Blank();
+        }
+        else
+        {
+            Write(" with message");
+            Serialize(expectedMessage);
+        }
+
+        return this;
+    }
+
+    public override string ToString() =>
+        output.ToString();
+
+    static string Indent(string multiline) =>
+        string.Join(Environment.NewLine, multiline.Split(Environment.NewLine).Select(x => $"    {x}"));
+}

--- a/src/Fixie.Assertions/StringUtilities.cs
+++ b/src/Fixie.Assertions/StringUtilities.cs
@@ -1,27 +1,99 @@
-﻿namespace Fixie.Assertions;
+﻿using System.Text;
+
+namespace Fixie.Assertions;
 
 static class StringUtilities
 {
-    public static string TypeName(Type x)
-        => x switch
+   public static string TypeName(Type type)
+    {
+        var keyword = type switch
+        {
+            _ when type == typeof(bool) => "bool",
+            _ when type == typeof(sbyte) => "sbyte",
+            _ when type == typeof(byte) => "byte",
+            _ when type == typeof(short) => "short",
+            _ when type == typeof(ushort) => "ushort",
+            _ when type == typeof(int) => "int",
+            _ when type == typeof(uint) => "uint",
+            _ when type == typeof(long) => "long",
+            _ when type == typeof(ulong) => "ulong",
+            _ when type == typeof(nint) => "nint",
+            _ when type == typeof(nuint) => "nuint",
+            _ when type == typeof(decimal) => "decimal",
+            _ when type == typeof(double) => "double",
+            _ when type == typeof(float) => "float",
+            _ when type == typeof(char) => "char",
+            _ when type == typeof(string) => "string",
+            _ when type == typeof(object) => "object",
+            _ => null
+        };
+
+        if (keyword != null)
+            return keyword;
+
+        if (type.IsGenericTypeParameter)
+            return "";
+
+        // When we have a combination of generics and nesting, where we may have 0..N generic type parameters
+        // introduced at each nesting level, the behavior of Type is surprising. At each level, GetGenericArguments()
+        // returns an array with items corresponding with ALL of the generic type parameters in the FULL name up
+        // to that point in the nesting, rather than only the number directly found on the nested type under
+        // inspection. Also, the contents of GetGenericArguments() at each intermediate level will describe the
+        // unspecified placeholder names, even if the overall incoming Type we're processing has real types
+        // specified.
+        //
+        // So, we may only trust the contents of the GetGenericArguments() array for the incoming Type we're
+        // processing, but we need to inspect the counts of each nesting level's GetGenericArguments() array as we
+        // go in order to know which of the trustworthy Types to place within <...> at each level.
+
+        var argumentsToApply = type.GetGenericArguments();
+
+        var scope = new Stack<Type>();
+        var walk = type;        
+        while(walk != null)
+        {
+            scope.Push(walk);
+            walk = walk.DeclaringType;
+        }
+
+        var result = new StringBuilder();
+        result.Append(type.Namespace);
+
+        var skip = 0;
+        foreach (var link in scope)
+        {
+            var take = link.GetGenericArguments().Length - skip;
+
+            result.Append('.');
+
+            if (take == 0)
             {
-                _ when x == typeof(bool) => "bool",
-                _ when x == typeof(sbyte) => "sbyte",
-                _ when x == typeof(byte) => "byte",
-                _ when x == typeof(short) => "short",
-                _ when x == typeof(ushort) => "ushort",
-                _ when x == typeof(int) => "int",
-                _ when x == typeof(uint) => "uint",
-                _ when x == typeof(long) => "long",
-                _ when x == typeof(ulong) => "ulong",
-                _ when x == typeof(nint) => "nint",
-                _ when x == typeof(nuint) => "nuint",
-                _ when x == typeof(decimal) => "decimal",
-                _ when x == typeof(double) => "double",
-                _ when x == typeof(float) => "float",
-                _ when x == typeof(char) => "char",
-                _ when x == typeof(string) => "string",
-                _ when x == typeof(object) => "object",
-                _ => x.ToString()
-            };
+                result.Append(link.Name);
+            }
+            else
+            {
+                var nameWithoutCount = link.Name.Substring(0, link.Name.IndexOf('`'));
+                result.Append(nameWithoutCount);
+                result.Append('<');
+
+                bool first = true;
+                foreach (var argument in argumentsToApply.Skip(skip).Take(take))
+                {
+                    if (!first)
+                        result.Append(',');
+
+                    if (!type.IsGenericTypeParameter)
+                        result.Append(TypeName(argument));
+
+                    first = false;
+                }
+
+                result.Append('>');
+            }
+                
+            skip += take;
+        }
+
+        return result.ToString();
+    }
 }

--- a/src/Fixie.Assertions/StringUtilities.cs
+++ b/src/Fixie.Assertions/StringUtilities.cs
@@ -1,19 +1,7 @@
-﻿using static System.Environment;
-
-namespace Fixie.Assertions;
+﻿namespace Fixie.Assertions;
 
 static class StringUtilities
 {
-    public static string Indent(string multiline) =>
-        string.Join(NewLine, multiline.Split(NewLine).Select(x => $"    {x}"));
-
-    public static bool IsMultiline(string value)
-    {
-        var lines = value.Split(NewLine);
-
-        return lines.Length > 1 && lines.All(line => !line.Contains('\r') && !line.Contains('\n'));
-    }
-
     public static string TypeName(Type x)
         => x switch
             {

--- a/src/Fixie.Assertions/StringUtilities.cs
+++ b/src/Fixie.Assertions/StringUtilities.cs
@@ -6,6 +6,18 @@ static class StringUtilities
 {
    public static string TypeName(Type type)
     {
+        if (type.IsGenericTypeParameter)
+            return "";
+
+        bool nullable = false;
+        var underlyingType = Nullable.GetUnderlyingType(type);
+
+        if (underlyingType != null)
+        {
+            type = underlyingType;
+            nullable = true;
+        }
+
         var keyword = type switch
         {
             _ when type == typeof(bool) => "bool",
@@ -29,10 +41,10 @@ static class StringUtilities
         };
 
         if (keyword != null)
-            return keyword;
+        {
+            return nullable ? keyword + "?" : keyword;
+        }
 
-        if (type.IsGenericTypeParameter)
-            return "";
 
         // When we have a combination of generics and nesting, where we may have 0..N generic type parameters
         // introduced at each nesting level, the behavior of Type is surprising. At each level, GetGenericArguments()
@@ -82,8 +94,13 @@ static class StringUtilities
                     if (!first)
                         result.Append(',');
 
-                    if (!type.IsGenericTypeParameter)
+                    if (!argument.IsGenericTypeParameter)
+                    {
+                        if (!first)
+                            result.Append(' ');
+
                         result.Append(TypeName(argument));
+                    }
 
                     first = false;
                 }
@@ -93,6 +110,9 @@ static class StringUtilities
                 
             skip += take;
         }
+
+        if (nullable)
+            result.Append('?');
 
         return result.ToString();
     }

--- a/src/Fixie.Assertions/Writer.cs
+++ b/src/Fixie.Assertions/Writer.cs
@@ -42,6 +42,13 @@ class Writer(StringBuilder output)
 
     public void WriteString(string value)
     {
+        bool IsMultiline(string value)
+        {
+            var lines = value.Split(Environment.NewLine);
+
+            return lines.Length > 1 && lines.All(line => !line.Contains('\r') && !line.Contains('\n'));
+        }
+
         if (IsMultiline(value))
         {
             var lengthAtOpenTerminalStart = output.Length;

--- a/src/Fixie.Assertions/Writer.cs
+++ b/src/Fixie.Assertions/Writer.cs
@@ -101,7 +101,7 @@ class Writer(StringBuilder output)
     {
         if (Enum.IsDefined(typeof(T), value))
         {
-            Append(typeof(T).FullName);
+            Append(TypeName(typeof(T)));
             Append('.');
             Append(value);
             return;
@@ -111,7 +111,7 @@ class Writer(StringBuilder output)
         bool negative = numeric.StartsWith('-');
 
         Append('(');
-        Append(typeof(T).FullName);
+        Append(TypeName(typeof(T)));
         Append(')');
 
         if (negative)

--- a/src/Fixie.Assertions/Writer.cs
+++ b/src/Fixie.Assertions/Writer.cs
@@ -7,7 +7,6 @@ namespace Fixie.Assertions;
 
 class Writer(StringBuilder output)
 {
-    readonly StringBuilder output = output;
     int indentation = 0;
     int lengthAtLineStart = 0;
 

--- a/src/Fixie.Assertions/Writer.cs
+++ b/src/Fixie.Assertions/Writer.cs
@@ -78,22 +78,8 @@ class Writer(StringBuilder output)
 
     public void WriteType(Type value)
     {
-        bool nullable = false;
-        var underlyingType = Nullable.GetUnderlyingType(value);
-
         Append("typeof(");
-
-        if (underlyingType != null)
-        {
-            value = underlyingType;
-            nullable = true;
-        }
-
         Append(TypeName(value));
-
-        if (nullable)
-            Append('?');
-        
         Append(')');
     }
 


### PR DESCRIPTION
Refactoring for message building, and related improvements to `TypeName` rendering since `Type.ToString()` does not provide text that doubles as valid C# syntax.