### PR TITLE
Serialize collections of key/value pairs as either `{...}` dictionaries or `[...]` lists as appropriate by inspecting the collection type's interfaces.

### DIFF
--- a/src/Fixie.Assertions.Tests/KeyValueTests.cs
+++ b/src/Fixie.Assertions.Tests/KeyValueTests.cs
@@ -336,34 +336,17 @@ class KeyValueTests
         nullablePairs.ShouldMatch([]);
     }
 
+    interface ICustomDictionary : IDictionary<int, string>
+    {
+    }
+
     class CustomDictionary(byte size) : ICustomDictionary
     {
         public IEnumerator<KeyValuePair<int, string>> GetEnumerator()
-            => new Enumerator(size);
+            => new PairEnumerator(size);
 
         IEnumerator IEnumerable.GetEnumerator()
             => GetEnumerator();
-
-        class Enumerator(byte size) : IEnumerator<KeyValuePair<int, string>>
-        {
-            int count = 0;
-
-            public KeyValuePair<int, string> Current => new(count, new('*', count));
-
-            object IEnumerator.Current => Current;
-
-            public bool MoveNext()
-            {
-                count++;
-
-                return count <= size;
-            }
-
-            public void Reset()
-                => count = 0;
-
-            public void Dispose() { }
-        }
 
         #region Members Irrelevant to the Serializer
 
@@ -390,8 +373,25 @@ class KeyValueTests
         #endregion
     }
 
-    interface ICustomDictionary : IDictionary<int, string>
+    class PairEnumerator(byte size) : IEnumerator<KeyValuePair<int, string>>
     {
+        int count = 0;
+
+        public KeyValuePair<int, string> Current => new(count, new('*', count));
+
+        object IEnumerator.Current => Current;
+
+        public bool MoveNext()
+        {
+            count++;
+
+            return count <= size;
+        }
+
+        public void Reset()
+            => count = 0;
+
+        public void Dispose() { }
     }
 
     const string Dictionary123 =

--- a/src/Fixie.Assertions.Tests/PropertyTests.cs
+++ b/src/Fixie.Assertions.Tests/PropertyTests.cs
@@ -172,9 +172,13 @@ class PropertyTests
                 },
                 NestedList = (HttpMethod[])[HttpMethod.Get, HttpMethod.Post],
                 NestedPairs = (KeyValuePair<string, string>[]) [
-                    new KeyValuePair<string, string>("A", "1"),
-                    new KeyValuePair<string, string>("B", "2")
+                    new("A", "1"),
+                    new("B", "2")
                 ],
+                NestedDictionary = new SortedDictionary<string, string> {
+                    ["A"] = "1",
+                    ["B"] = "2"
+                },
                 NestedDynamic =  (dynamic) new {
                     Name = "Dynamic",
                     Age = -1
@@ -200,7 +204,17 @@ class PropertyTests
                             Method = "POST"
                           }
                         ],
-                        NestedPairs = {
+                        NestedPairs = [
+                          {
+                            Key = "A",
+                            Value = "1"
+                          },
+                          {
+                            Key = "B",
+                            Value = "2"
+                          }
+                        ],
+                        NestedDictionary = {
                           ["A"] = "1",
                           ["B"] = "2"
                         },

--- a/src/Fixie.Assertions/Serializer.cs
+++ b/src/Fixie.Assertions/Serializer.cs
@@ -131,7 +131,15 @@ class Serializer
         => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>);
 
     static bool IsDictionaryInterface(Type type)
-        => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IDictionary<,>);
+    {
+        if (!type.IsGenericType)
+            return false;
+
+        var definition = type.GetGenericTypeDefinition();
+
+        return definition == typeof(IDictionary<,>)
+            || definition == typeof(IReadOnlyDictionary<,>);
+    }
 
     static MethodInfo GetDynamicWriter(string method, params Type[] typeArguments)
     {

--- a/src/Fixie.Assertions/Serializer.cs
+++ b/src/Fixie.Assertions/Serializer.cs
@@ -71,54 +71,67 @@ class Serializer
 
     static MethodInfo GetDynamicConverter(Type type)
     {
-        if (IsPairType(type, out var keyType, out var valueType))
-            return GetDynamicWriter(nameof(Writer.WritePairs), keyType, valueType);
+        if (HasDictionaryRepresentation(type, out var keyType, out var valueType))
+            return GetDynamicWriter(nameof(Writer.WriteDictionary), keyType, valueType);
 
-        if (IsEnumerableType(type, out var itemType))
+        if (HasListRepresentation(type, out var itemType))
             return GetDynamicWriter(nameof(Writer.WriteList), itemType);
 
-        return GetDynamicWriter(
-            type.IsEnum
-                ? nameof(Writer.WriteEnum)
-                : nameof(Writer.WriteProperties), type);
+        if (type.IsEnum)
+            return GetDynamicWriter(nameof(Writer.WriteEnum), type);
+
+        return GetDynamicWriter(nameof(Writer.WriteProperties), type);
     }
 
-    static bool IsPairType(Type typeToConvert,
+    static bool HasDictionaryRepresentation(Type typeToConvert,
         [NotNullWhen(true)] out Type? keyType,
         [NotNullWhen(true)] out Type? valueType)
     {
-        if (IsEnumerableType(typeToConvert, out var itemType))
-        {
-            if (itemType.IsGenericType &&
-                itemType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
-            {
-                var typeArguments = itemType.GetGenericArguments();
+        var interfaceType =
+            IsDictionaryInterface(typeToConvert)
+                ? typeToConvert
+                : typeToConvert.GetInterfaces().FirstOrDefault(IsDictionaryInterface);
 
-                keyType = typeArguments[0];
-                valueType = typeArguments[1];
-                return true;
-            }
+        if (interfaceType == null)
+        {
+            keyType = null;
+            valueType = null;
+            
+            return false;
         }
 
-        keyType = null;
-        valueType = null;
-        return false;
+        var typeArguments = interfaceType.GetGenericArguments();
+        
+        keyType = typeArguments[0];
+        valueType = typeArguments[1];
+        
+        return true;
     }
 
-    static bool IsEnumerableType(Type typeToConvert, [NotNullWhen(true)] out Type? itemType)
+    static bool HasListRepresentation(Type typeToConvert, [NotNullWhen(true)] out Type? itemType)
     {
-        var enumerableType =
-            IsEnumerableT(typeToConvert)
+        var interfaceType =
+            IsEnumerableInterface(typeToConvert)
                 ? typeToConvert
-                : typeToConvert.GetInterfaces().FirstOrDefault(IsEnumerableT);
+                : typeToConvert.GetInterfaces().FirstOrDefault(IsEnumerableInterface);
 
-        itemType = enumerableType?.GetGenericArguments()[0];
+        if (interfaceType == null)
+        {
+            itemType = null;
 
-        return itemType != null;
+            return false;
+        }
+
+        itemType = interfaceType.GetGenericArguments()[0];
+
+        return true;
     }
 
-    static bool IsEnumerableT(Type type)
+    static bool IsEnumerableInterface(Type type)
         => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>);
+
+    static bool IsDictionaryInterface(Type type)
+        => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IDictionary<,>);
 
     static MethodInfo GetDynamicWriter(string method, params Type[] typeArguments)
     {

--- a/src/Fixie.Assertions/Writer.cs
+++ b/src/Fixie.Assertions/Writer.cs
@@ -114,7 +114,7 @@ class Writer(StringBuilder output)
         WriteItems('[', items, ']', WriteSerialized);
     }
 
-    public void WritePairs<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> pairs)
+    public void WriteDictionary<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> pairs)
     {
         WriteItems('{', pairs, '}', pair =>
         {


### PR DESCRIPTION
Before this PR, all `IEnumerable<KeyValuePair<TKey, TValue>>` would be treated as dictionaries and serialized with dictionary syntax. Doing so is not always accurate because a simple `List<KeyValuePair<TKey, TValue>>` is meaningfully ordered and has a more natural list representation available to it in the serializer.

Seeking a better way to determine when dictionary style syntax is more appropriate, this PR first settles on `IDictionary<TKey, TValue>` as being the better type to detect. Then, it augments that by also considering `IReadOnlyDictionary<TKey, TValue>`. Note there is no inheritance relationship between those two interface types, so we have to check for both explicitly. Howver, in both cases, the `Writer.WriteDictionary(...)` method is still able to perform the actual work by treating them as `IEnumerable<KeyValuePair<TKey, TValue>>` which they both implement. In other words we only enter `Writer.WriteDictionary(...)` for actual dictionary types, but once we're there the work proceeds as it already had.

This is important because a subsequent PR will attempt to sort dictionaries by key during serialization in the interest of stable representations, and doing so would be wildly inaccurate for non-dictionary collections of pairs.
