### PR TITLE
Simplify assertion exceptions to fit actual use caes.

### DIFF
--- a/src/Fixie.Assertions.Tests/DiffToolReport.cs
+++ b/src/Fixie.Assertions.Tests/DiffToolReport.cs
@@ -19,7 +19,7 @@ class DiffToolReport : IHandler<TestFailed>, IHandler<ExecutionCompleted>
 
     public async Task Handle(ExecutionCompleted message)
     {
-        if (singleFailure is AssertException failure)
+        if (singleFailure is ComparisonException failure)
         {
             if (failure.HasMultilineRepresentation)
                 await LaunchDiffTool(failure.Expected, failure.Actual);

--- a/src/Fixie.Assertions.Tests/DiffToolReport.cs
+++ b/src/Fixie.Assertions.Tests/DiffToolReport.cs
@@ -21,8 +21,7 @@ class DiffToolReport : IHandler<TestFailed>, IHandler<ExecutionCompleted>
     {
         if (singleFailure is ComparisonException failure)
         {
-            if (failure.HasMultilineRepresentation)
-                await LaunchDiffTool(failure.Expected, failure.Actual);
+            await LaunchDiffTool(failure.Expected, failure.Actual);
         }
         else if (singleFailure is ContradictionException contradiction)
         {

--- a/src/Fixie.Assertions/AssertException.cs
+++ b/src/Fixie.Assertions/AssertException.cs
@@ -39,3 +39,11 @@ public class AssertException : Exception
         return string.Join(NewLine, results.ToArray());
     }
 }
+
+public class ComparisonException : AssertException
+{
+    public ComparisonException(string expression, string expected, string actual, string message)
+        : base(expression, expected, actual, message, true)
+    {
+    }
+}

--- a/src/Fixie.Assertions/AssertException.cs
+++ b/src/Fixie.Assertions/AssertException.cs
@@ -2,16 +2,8 @@
 
 namespace Fixie.Assertions;
 
-public class AssertException : Exception
+public class AssertException(string message) : Exception(message)
 {
-    public string Expression { get; }
-
-    public AssertException(string expression, string message)
-        : base(message)
-    {
-        Expression = expression;
-    }
-
     public override string? StackTrace => FilterStackTrace(base.StackTrace);
 
     static string FilterStackTraceAssemblyPrefix = typeof(AssertException).Namespace + ".";
@@ -34,15 +26,8 @@ public class AssertException : Exception
     }
 }
 
-public class ComparisonException : AssertException
+public class ComparisonException(string expected, string actual, string message) : AssertException(message)
 {
-    public string Expected { get; }
-    public string Actual { get; }
-
-    public ComparisonException(string expression, string expected, string actual, string message)
-        : base(expression, message)
-    {
-        Expected = expected;
-        Actual = actual;
-    }
+    public string Expected { get => expected; }
+    public string Actual { get => actual; }
 }

--- a/src/Fixie.Assertions/AssertException.cs
+++ b/src/Fixie.Assertions/AssertException.cs
@@ -5,15 +5,11 @@ namespace Fixie.Assertions;
 public class AssertException : Exception
 {
     public string Expression { get; }
-    public string Expected { get; }
-    public string Actual { get; }
 
-    public AssertException(string expression, string expected, string actual, string message)
+    public AssertException(string expression, string message)
         : base(message)
     {
         Expression = expression;
-        Expected = expected;
-        Actual = actual;
     }
 
     public override string? StackTrace => FilterStackTrace(base.StackTrace);
@@ -40,8 +36,13 @@ public class AssertException : Exception
 
 public class ComparisonException : AssertException
 {
+    public string Expected { get; }
+    public string Actual { get; }
+
     public ComparisonException(string expression, string expected, string actual, string message)
-        : base(expression, expected, actual, message)
+        : base(expression, message)
     {
+        Expected = expected;
+        Actual = actual;
     }
 }

--- a/src/Fixie.Assertions/AssertException.cs
+++ b/src/Fixie.Assertions/AssertException.cs
@@ -7,15 +7,13 @@ public class AssertException : Exception
     public string Expression { get; }
     public string Expected { get; }
     public string Actual { get; }
-    public bool HasMultilineRepresentation { get; }
 
-    public AssertException(string expression, string expected, string actual, string message, bool hasMultilineRepresentation = false)
+    public AssertException(string expression, string expected, string actual, string message)
         : base(message)
     {
         Expression = expression;
         Expected = expected;
         Actual = actual;
-        HasMultilineRepresentation = hasMultilineRepresentation;
     }
 
     public override string? StackTrace => FilterStackTrace(base.StackTrace);
@@ -43,7 +41,7 @@ public class AssertException : Exception
 public class ComparisonException : AssertException
 {
     public ComparisonException(string expression, string expected, string actual, string message)
-        : base(expression, expected, actual, message, true)
+        : base(expression, expected, actual, message)
     {
     }
 }

--- a/src/Fixie.Assertions/AssertException.cs
+++ b/src/Fixie.Assertions/AssertException.cs
@@ -9,7 +9,7 @@ public class AssertException : Exception
     public string Actual { get; }
     public bool HasMultilineRepresentation { get; }
 
-    public AssertException(string expression, string expected, string actual, string message, bool hasMultilineRepresentation)
+    public AssertException(string expression, string expected, string actual, string message, bool hasMultilineRepresentation = false)
         : base(message)
     {
         Expression = expression;

--- a/src/Fixie.Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Assertions/AssertionExtensions.cs
@@ -54,7 +54,7 @@ public static class AssertionExtensions
                 .Block(expectedPattern)
                 .Write("but was")
                 .Block(actualTypeName)
-                .ToString(), true);
+                .ToString());
     }
 
     /// <summary>
@@ -64,7 +64,7 @@ public static class AssertionExtensions
     public static T ShouldNotBeNull<T>([NotNull] this T? actual, [CallerArgumentExpression(nameof(actual))] string expression = default!)
         where T : class
     {
-        return actual ?? throw new AssertException(expression, "not null", "null", $"{expression} should not be null but was null.", false);
+        return actual ?? throw new AssertException(expression, "not null", "null", $"{expression} should not be null but was null.");
     }
 
     /// <summary>
@@ -74,7 +74,7 @@ public static class AssertionExtensions
     public static T ShouldNotBeNull<T>([NotNull] this T? actual, [CallerArgumentExpression(nameof(actual))] string expression = default!)
          where T : struct
     {
-        return actual ?? throw new AssertException(expression, "not null", "null", $"{expression} should not be null but was null.", false);
+        return actual ?? throw new AssertException(expression, "not null", "null", $"{expression} should not be null but was null.");
     }
 
     /// <summary>
@@ -244,7 +244,7 @@ public static class AssertionExtensions
 
              You may need to cast the target to either Action or Func<Task>,
              or wrap it in an equivalent lambda expression.
-             """, false);
+             """);
     }
 
     static string Signature(MethodInfo function)
@@ -274,7 +274,7 @@ public static class AssertionExtensions
                         .ShouldHaveThrown<TException>(expression, expectedMessage)
                         .Write("but instead the message was")
                         .Serialize(actual.Message)
-                        .ToString(), false);
+                        .ToString());
 
             return typed;
         }
@@ -289,9 +289,9 @@ public static class AssertionExtensions
                 .Serialize(actual.Message);
 
         if (expectedMessage == null)
-            throw new AssertException(expression, expectedType, actualType, failure.ToString(), false);
+            throw new AssertException(expression, expectedType, actualType, failure.ToString());
 
-        throw new AssertException(expression, expectedMessage, actual.Message, failure.ToString(), false);
+        throw new AssertException(expression, expectedMessage, actual.Message, failure.ToString());
     }
 
     static void ShouldHaveThrown<TException>(string expression, string? expectedMessage) where TException : Exception
@@ -302,7 +302,7 @@ public static class AssertionExtensions
             new Message()
                 .ShouldHaveThrown<TException>(expression, expectedMessage)
                 .Write("but no exception was thrown.")
-                .ToString(), false);
+                .ToString());
     }
 
     /// <summary>
@@ -323,7 +323,7 @@ public static class AssertionExtensions
                 .Write("but was")
                 .Block(actualStructure);
 
-            throw new AssertException(expression, expectationBody, actualStructure, failure.ToString(), true);
+            throw new AssertException(expression, expectationBody, actualStructure, failure.ToString());
         }
     }
 

--- a/src/Fixie.Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Assertions/AssertionExtensions.cs
@@ -48,7 +48,7 @@ public static class AssertionExtensions
         var expectedPattern = $"is {TypeName(typeof(T))}";
         var actualTypeName = actual == null ? "null" : TypeName(actual.GetType());
 
-        throw new AssertException(expression, expectedPattern, actualTypeName,
+        throw new AssertException(expression,
             new Message()
                 .Write(expression, " should match the type pattern")
                 .Block(expectedPattern)
@@ -64,7 +64,7 @@ public static class AssertionExtensions
     public static T ShouldNotBeNull<T>([NotNull] this T? actual, [CallerArgumentExpression(nameof(actual))] string expression = default!)
         where T : class
     {
-        return actual ?? throw new AssertException(expression, "not null", "null", $"{expression} should not be null but was null.");
+        return actual ?? throw new AssertException(expression, $"{expression} should not be null but was null.");
     }
 
     /// <summary>
@@ -74,7 +74,7 @@ public static class AssertionExtensions
     public static T ShouldNotBeNull<T>([NotNull] this T? actual, [CallerArgumentExpression(nameof(actual))] string expression = default!)
          where T : struct
     {
-        return actual ?? throw new AssertException(expression, "not null", "null", $"{expression} should not be null but was null.");
+        return actual ?? throw new AssertException(expression, $"{expression} should not be null but was null.");
     }
 
     /// <summary>
@@ -224,7 +224,7 @@ public static class AssertionExtensions
 
         var actualSignature = Signature(shouldThrow.Method);
 
-        throw new AssertException(expression, "Action or Func<Task>", actualSignature,
+        throw new AssertException(expression,
             $"""
              {expression} has a function type compatible with
 
@@ -269,7 +269,7 @@ public static class AssertionExtensions
         if (actual is TException typed)
         {
             if (expectedMessage != null && actual.Message != expectedMessage)
-                throw new AssertException(expression, expectedMessage, actual.Message,
+                throw new AssertException(expression,
                     new Message()
                         .ShouldHaveThrown<TException>(expression, expectedMessage)
                         .Write("but instead the message was")
@@ -289,16 +289,16 @@ public static class AssertionExtensions
                 .Serialize(actual.Message);
 
         if (expectedMessage == null)
-            throw new AssertException(expression, expectedType, actualType, failure.ToString());
+            throw new AssertException(expression, failure.ToString());
 
-        throw new AssertException(expression, expectedMessage, actual.Message, failure.ToString());
+        throw new AssertException(expression, failure.ToString());
     }
 
     static void ShouldHaveThrown<TException>(string expression, string? expectedMessage) where TException : Exception
     {
         var expectedType = TypeName(typeof(TException));
 
-        throw new AssertException(expression, expectedType, "no exception was thrown",
+        throw new AssertException(expression,
             new Message()
                 .ShouldHaveThrown<TException>(expression, expectedMessage)
                 .Write("but no exception was thrown.")
@@ -323,7 +323,7 @@ public static class AssertionExtensions
                 .Write("but was")
                 .Block(actualStructure);
 
-            throw new AssertException(expression, expectationBody, actualStructure, failure.ToString());
+            throw new AssertException(expression, failure.ToString());
         }
     }
 

--- a/src/Fixie.Assertions/AssertionExtensions.cs
+++ b/src/Fixie.Assertions/AssertionExtensions.cs
@@ -32,7 +32,7 @@ public static class AssertionExtensions
                     "These serialized values are identical. Did you mean to perform " +
                     "a structural comparison with `ShouldMatch` instead?");
 
-            throw new AssertException(expression, expectedStructure, actualStructure, failure.ToString(), true);
+            throw new ComparisonException(expression, expectedStructure, actualStructure, failure.ToString());
         }
     }
 
@@ -87,13 +87,13 @@ public static class AssertionExtensions
         var expectedStructure = Serialize(expected);
 
         if (actualStructure != expectedStructure)
-            throw new AssertException(expression, expectedStructure, actualStructure,
+            throw new ComparisonException(expression, expectedStructure, actualStructure,
                 new Message()
                     .Write(expression, " should match")
                     .Block(expectedStructure)
                     .Write("but was")
                     .Block(actualStructure)
-                    .ToString(), true);
+                    .ToString());
     }
 
     /// <summary>


### PR DESCRIPTION
* Simplify public properties of AssertException based on actual usages.
* Introduce subclass specific to comparisons (equality and strucutral equality) where there is a specific Expected and Actual value worthy of displaying in a diff tool.
