### PR TITLE
Property and key stability

### DIFF
--- a/src/Fixie.Assertions.Tests/GeneralAssertionTests.cs
+++ b/src/Fixie.Assertions.Tests/GeneralAssertionTests.cs
@@ -177,8 +177,8 @@ class GeneralAssertionTests
             x should match
 
                 {
-                  Value = 1,
-                  Extra = 'A'
+                  Extra = 'A',
+                  Value = 1
                 }
 
             but was

--- a/src/Fixie.Assertions.Tests/KeyValueTests.cs
+++ b/src/Fixie.Assertions.Tests/KeyValueTests.cs
@@ -13,17 +13,19 @@ class KeyValueTests
             ["First Key"] = "First Value",
             ["Second Key"] = "Second Value",
             ["Third Key"] = "Third Value"
-        }).ShouldBe("""
-                    {
-                      ["First Key"] = "First Value",
-                      ["Second Key"] = "Second Value",
-                      ["Third Key"] = "Third Value"
-                    }
-                    """);
+        }).ShouldBe(FirstSecondThird);
     }
 
     public void ShouldSerializeIDictionaryAndSubtypesUsingKeyValuePairSyntax()
     {
+        Serialize((SortedDictionary<string, string>)[]).ShouldBe("{}");
+        Serialize(new SortedDictionary<string, string>
+        {
+            ["Third Key"] = "Third Value",
+            ["First Key"] = "First Value",
+            ["Second Key"] = "Second Value"
+        }).ShouldBe(FirstSecondThird);
+
         Serialize(new CustomDictionary(0)).ShouldBe("{}");
         Serialize(new CustomDictionary(1))
             .ShouldBe("""
@@ -32,6 +34,7 @@ class KeyValueTests
                       }
                       """);
         Serialize(new CustomDictionary(3)).ShouldBe(Dictionary123);
+
         Serialize((ICustomDictionary)new CustomDictionary(3)).ShouldBe(Dictionary123);
         Serialize((IDictionary<int, string>)new CustomDictionary(3)).ShouldBe(Dictionary123);
     }
@@ -136,6 +139,7 @@ class KeyValueTests
     {
         Serialize((Dictionary<string, object>?)null).ShouldBe("null");
         Serialize((IDictionary<string, object>?)null).ShouldBe("null");
+        Serialize((SortedDictionary<string, object>?)null).ShouldBe("null");
         Serialize((CustomDictionary?)null).ShouldBe("null");
         Serialize((ICustomDictionary?)null).ShouldBe("null");
         Serialize((CustomReadOnlyDictionary?)null).ShouldBe("null");
@@ -434,6 +438,15 @@ class KeyValueTests
 
         public void Dispose() { }
     }
+
+    const string FirstSecondThird =
+        """
+        {
+          ["First Key"] = "First Value",
+          ["Second Key"] = "Second Value",
+          ["Third Key"] = "Third Value"
+        }
+        """;
 
     const string Dictionary123 =
         """

--- a/src/Fixie.Assertions.Tests/PropertyTests.cs
+++ b/src/Fixie.Assertions.Tests/PropertyTests.cs
@@ -512,7 +512,7 @@ class PropertyTests
         These serialized values are identical. Did you mean to perform a structural comparison with `ShouldMatch` instead?
         """;
 
-        const string ShouldBe00ButWasNull =
+    const string ShouldBe00ButWasNull =
         """
         x should be
         

--- a/src/Fixie.Assertions.Tests/PropertyTests.cs
+++ b/src/Fixie.Assertions.Tests/PropertyTests.cs
@@ -61,16 +61,16 @@ class PropertyTests
             })
             .ShouldBe("""
                       {
-                        Name = "Anonymous",
-                        Age = 64
+                        Age = 64,
+                        Name = "Anonymous"
                       }
                       """);
 
         Serialize(new Person("Alex", 32))
             .ShouldBe("""
                       {
-                        Name = "Alex",
-                        Age = 32
+                        Age = 32,
+                        Name = "Alex"
                       }
                       """);
 
@@ -118,8 +118,8 @@ class PropertyTests
         Serialize(sampleWithIndexer)
             .ShouldBe("""
                       {
-                        Name = "Alex",
-                        Age = 32
+                        Age = 32,
+                        Name = "Alex"
                       }
                       """);
 
@@ -131,8 +131,8 @@ class PropertyTests
         string serialized = Serialize(dynamic);
         serialized.ShouldBe("""
                                {
-                                 Name = "Dynamic",
-                                 Age = -1
+                                 Age = -1,
+                                 Name = "Dynamic"
                                }
                                """);
     }
@@ -151,8 +151,8 @@ class PropertyTests
             .ShouldBe("""
                       {
                         ChildField = 'B',
-                        ParentField = 1,
                         ChildProperty = 2,
+                        ParentField = 1,
                         ParentProperty = 'A'
                       }
                       """);
@@ -186,15 +186,15 @@ class PropertyTests
             })
             .ShouldBe("""
                       {
-                        Name = "Anonymous",
                         Age = 64,
-                        NestedReference = {
-                          Name = "Alex",
-                          Age = 32
+                        Name = "Anonymous",
+                        NestedDictionary = {
+                          ["A"] = "1",
+                          ["B"] = "2"
                         },
-                        NestedValue = {
-                          X = 1,
-                          Y = 2
+                        NestedDynamic = {
+                          Age = -1,
+                          Name = "Dynamic"
                         },
                         NestedList = [
                           {
@@ -214,13 +214,13 @@ class PropertyTests
                             Value = "2"
                           }
                         ],
-                        NestedDictionary = {
-                          ["A"] = "1",
-                          ["B"] = "2"
+                        NestedReference = {
+                          Age = 32,
+                          Name = "Alex"
                         },
-                        NestedDynamic = {
-                          Name = "Dynamic",
-                          Age = -1
+                        NestedValue = {
+                          X = 1,
+                          Y = 2
                         }
                       }
                       """);

--- a/src/Fixie.Assertions.Tests/SerializerProtectionTests.cs
+++ b/src/Fixie.Assertions.Tests/SerializerProtectionTests.cs
@@ -42,19 +42,19 @@ class SerializerProtectionTests
         Serializer.Serialize(founder)
             .ShouldBe("""
                       {
-                        Name = "Morgan",
-                        Manager = null
+                        Manager = null,
+                        Name = "Morgan"
                       }
                       """);
 
         Serializer.Serialize(supervisor)
             .ShouldBe("""
                       {
-                        Name = "Riley",
                         Manager = {
-                          Name = "Morgan",
-                          Manager = null
-                        }
+                          Manager = null,
+                          Name = "Morgan"
+                        },
+                        Name = "Riley"
                       }
                       """);
 
@@ -67,8 +67,8 @@ class SerializerProtectionTests
         Serializer.Serialize(ouroboros)
             .ShouldBe("""
                       {
-                        Name = "Ouroboros",
-                        Manager = null
+                        Manager = null,
+                        Name = "Ouroboros"
                       }
                       """);
 
@@ -103,14 +103,11 @@ class SerializerProtectionTests
         Serializer.Serialize(model)
             .ShouldBe("""
                       {
-                        JsonIgnored = "Property Value From JsonIgnored",
-                        JsonCustomizedName = "Property Value From JsonCustomizedName",
                         JsonCustomConverted = {
                           Key = "Key/Value Pair",
                           Value = "From JsonCustomConverted"
                         },
-                        JsonNotIgnoredBecauseNonNull = "Property Value From JsonNotIgnoredBecauseNonNull",
-                        JsonIgnoredBecauseNull = null,
+                        JsonCustomizedName = "Property Value From JsonCustomizedName",
                         JsonExtendedData = {
                           ["A"] = {
                             ValueKind = System.Text.Json.JsonValueKind.Number
@@ -118,7 +115,10 @@ class SerializerProtectionTests
                           ["B"] = {
                             ValueKind = System.Text.Json.JsonValueKind.Number
                           }
-                        }
+                        },
+                        JsonIgnored = "Property Value From JsonIgnored",
+                        JsonIgnoredBecauseNull = null,
+                        JsonNotIgnoredBecauseNonNull = "Property Value From JsonNotIgnoredBecauseNonNull"
                       }
                       """);
     }
@@ -234,67 +234,36 @@ class SerializerProtectionTests
         A value could not be serialized because its object graph is too deep. Below is the start of the message that was interrupted:
     
         {
-          Name = "Ouroboros",
           Manager = {
-            Name = "Ouroboros",
             Manager = {
-              Name = "Ouroboros",
               Manager = {
-                Name = "Ouroboros",
                 Manager = {
-                  Name = "Ouroboros",
                   Manager = {
-                    Name = "Ouroboros",
                     Manager = {
-                      Name = "Ouroboros",
                       Manager = {
-                        Name = "Ouroboros",
                         Manager = {
-                          Name = "Ouroboros",
                           Manager = {
-                            Name = "Ouroboros",
                             Manager = {
-                              Name = "Ouroboros",
                               Manager = {
-                                Name = "Ouroboros",
                                 Manager = {
-                                  Name = "Ouroboros",
                                   Manager = {
-                                    Name = "Ouroboros",
                                     Manager = {
-                                      Name = "Ouroboros",
                                       Manager = {
-                                        Name = "Ouroboros",
                                         Manager = {
-                                          Name = "Ouroboros",
                                           Manager = {
-                                            Name = "Ouroboros",
                                             Manager = {
-                                              Name = "Ouroboros",
                                               Manager = {
-                                                Name = "Ouroboros",
                                                 Manager = {
-                                                  Name = "Ouroboros",
                                                   Manager = {
-                                                    Name = "Ouroboros",
                                                     Manager = {
-                                                      Name = "Ouroboros",
                                                       Manager = {
-                                                        Name = "Ouroboros",
                                                         Manager = {
-                                                          Name = "Ouroboros",
                                                           Manager = {
-                                                            Name = "Ouroboros",
                                                             Manager = {
-                                                              Name = "Ouroboros",
                                                               Manager = {
-                                                                Name = "Ouroboros",
                                                                 Manager = {
-                                                                  Name = "Ouroboros",
                                                                   Manager = {
-                                                                    Name = "Ouroboros",
                                                                     Manager = {
-                                                                      Name = "Ouroboros",
                                                                       Manager = {
 
         """;

--- a/src/Fixie.Assertions.Tests/TextTests.cs
+++ b/src/Fixie.Assertions.Tests/TextTests.cs
@@ -377,23 +377,19 @@ class TextTests
             """"
             [
               {
-                Text = "ABC",
                 Inner = {
                   Text = "DEF"
-                },
-                Pairs = {
-                  ["ABC"] = "DEF"
                 },
                 List = [
                   "GHI",
                   "JKL"
-                ]
+                ],
+                Pairs = {
+                  ["ABC"] = "DEF"
+                },
+                Text = "ABC"
               },
               {
-                Text = """
-                       Line 1
-                       Line 2
-                       """,
                 Inner = {
                   Text = """
                          
@@ -401,6 +397,19 @@ class TextTests
                          Line 3
                          """
                 },
+                List = [
+                  """
+                  Line 1
+                  Line 2
+                  Line 3
+                  """,
+                  "ABC",
+                  """
+                  Line 1
+                  Line 2
+                  Line 3
+                  """
+                ],
                 Pairs = {
                   ["ABC"] = """
                             Line 1
@@ -420,19 +429,10 @@ class TextTests
                           
                           """
                 },
-                List = [
-                  """
-                  Line 1
-                  Line 2
-                  Line 3
-                  """,
-                  "ABC",
-                  """
-                  Line 1
-                  Line 2
-                  Line 3
-                  """
-                ]
+                Text = """
+                       Line 1
+                       Line 2
+                       """
               }
             ]
             """");

--- a/src/Fixie.Assertions/Writer.cs
+++ b/src/Fixie.Assertions/Writer.cs
@@ -147,7 +147,7 @@ class Writer(StringBuilder output)
                 })
                 .Select(property => (property.Name, Value: property.GetValue(value)));
 
-        WriteItems('{', fields.Concat(properties), '}', property =>
+        WriteItems('{', fields.Concat(properties).OrderBy(x => x.Name), '}', property =>
         {
             Append(property.Name);
             Append(" = ");

--- a/src/Fixie.Assertions/Writer.cs
+++ b/src/Fixie.Assertions/Writer.cs
@@ -116,7 +116,7 @@ class Writer(StringBuilder output)
 
     public void WriteDictionary<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> pairs)
     {
-        WriteItems('{', pairs, '}', pair =>
+        WriteItems('{', pairs.OrderBy(x => x.Key), '}', pair =>
         {
             Append('[');
             WriteSerialized(pair.Key);


### PR DESCRIPTION
To ensure stability of assertion messages and of structural comparisons, properties/fields and dictionary keys are sorted during serialization. When a dictionary key type cannot be sorted, output still continues but with a warning comment handy when an unstable `ShouldMatch` fails.