### PR TITLE
Add target framework `net9.0`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            8.0
+            9.0
       - run: dotnet --info
       - name: Build
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            8.0
+            9.0
       - run: dotnet --info
       - name: Build
         env:

--- a/build.ps1
+++ b/build.ps1
@@ -12,7 +12,7 @@ if (test-path packages) { remove-item packages -Recurse }
 
 step { dotnet tool restore }
 step { dotnet clean src -c Release --nologo -v minimal }
-step { dotnet build src -c Release --nologo --tl }
+step { dotnet build src -c Release --nologo }
 step { dotnet fixie *.Tests -c Release --no-build }
 
 if ($pack) {

--- a/src/Fixie.Assertions.Tests/Fixie.Assertions.Tests.csproj
+++ b/src/Fixie.Assertions.Tests/Fixie.Assertions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace>Tests</RootNamespace>
   </PropertyGroup>
 

--- a/src/Fixie.Assertions.Tests/TextTests.cs
+++ b/src/Fixie.Assertions.Tests/TextTests.cs
@@ -94,16 +94,15 @@ class TextTests
                       '\r'
                       """);
 
-        // TODO: Applicable in C# 13
         // Escape Sequence: Escape
-        // Serialize('\u001B')
-        //     .ShouldBe("""
-        //               '\e'
-        //               """);
-        // Serialize('\e')
-        //     .ShouldBe("""
-        //               '\e'
-        //               """);
+        Serialize('\u001B')
+            .ShouldBe("""
+                      '\e'
+                      """);
+        Serialize('\e')
+            .ShouldBe("""
+                      '\e'
+                      """);
 
         // Literal Space
         Serialize('\u0020')
@@ -180,10 +179,9 @@ class TextTests
                       "\0\0 \a\a \b\b \t\t \n\n \r\r"
                       """);
 
-        // TODO: In C# 13, include \u001B\e becoming \e\e
-        Serialize("\u000C\f \u000B\v \u0022\" \u0027\' \u005C\\")
+        Serialize("\u000C\f \u000B\v \u001B\e \u0022\" \u0027\' \u005C\\")
             .ShouldBe("""
-                      "\f\f \v\v \"\" '' \\\\"
+                      "\f\f \v\v \e\e \"\" '' \\\\"
                       """);
 
         foreach (var c in UnicodeEscapedCharacters())
@@ -576,7 +574,8 @@ class TextTests
         // '\uHHHH' hex escape sequences.
 
         for (char c = '\u0001'; c <= '\u0006'; c++) yield return c;
-        for (char c = '\u000E'; c <= '\u001F'; c++) yield return c;
+        for (char c = '\u000E'; c <= '\u001A'; c++) yield return c;
+        for (char c = '\u001C'; c <= '\u001F'; c++) yield return c;
         yield return '\u007F';
         for (char c = '\u0080'; c <= '\u009F'; c++) yield return c;
 

--- a/src/Fixie.Assertions/Fixie.Assertions.csproj
+++ b/src/Fixie.Assertions/Fixie.Assertions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Fixie, Patrick Lioi</Authors>
     <Copyright>Copyright (c) 2024 Patrick Lioi</Copyright>

--- a/src/Fixie.Assertions/Message.cs
+++ b/src/Fixie.Assertions/Message.cs
@@ -9,7 +9,7 @@ class Message
 
     bool endsWithBlock = false;
 
-    public Message Write(params string[] parts)
+    public Message Write(params ReadOnlySpan<string> parts)
     {
         if (endsWithBlock)
             Blank();

--- a/src/Fixie.Assertions/Writer.cs
+++ b/src/Fixie.Assertions/Writer.cs
@@ -270,7 +270,7 @@ class Writer(StringBuilder output)
             '\v' => @"\v",
             '\f' => @"\f",
             '\r' => @"\r",
-            //'\e' => @"\e", TODO: Applicable in C# 13
+            '\e' => @"\e",
             ' ' => " ",
             '"' => literal == Literal.String ? @"\""" : char.ToString(ch),
             '\'' => literal == Literal.Character ? @"\'" : char.ToString(ch),


### PR DESCRIPTION
This adds target framework `net9.0` where appropriate:

* Ensure that the GitHub Actions build environment includes the .NET 9 SDK.
* Remove the "terminal logger" command line flag, as it is the default behavior starting in the .NET 9 SDK.
* Switch to target framework `net9.0`.
* String serialization respects the '\e' escape sequence introduced in C# 13.
* Eliminate wasteful array allocations on every call to `Message.Write(...)` using `params ReadOnlySpan<string>`.